### PR TITLE
changing search regex

### DIFF
--- a/lib/zotero-citations.coffee
+++ b/lib/zotero-citations.coffee
@@ -112,7 +112,7 @@ module.exports = ZoteroScan =
     bibliography = null
     citekeys = []
     citedlines = []
-    matchregex = /\[([^\]]*)\]\[([^\]]+)\]/g
+    matchregex = /\[([^]*?)\]\[([^\]]+)\]/g
     for line, lineno in editor.getBuffer().getLines()
       console.log(line)
 
@@ -145,7 +145,7 @@ module.exports = ZoteroScan =
     # replace citation text at second run
     for lineno in citedlines
       line = editor.getBuffer().getLines()[lineno]
-      cited = line.replace(/\[([^\]]*)\]\[([^\]]+)\]/g, @citation)
+      cited = line.replace(matchregex, @citation)
       if line != cited
         editor.setTextInBufferRange([[lineno, 0], [lineno, line.length]], cited)
 


### PR DESCRIPTION
I would like to propose an alternative regex for searching links.

The problem with previous regex (`/\[([^\]]*)\]\[([^\]]+)\]/g` ) is when `]` character is inside citation, at next scan this was not qualified as a valid link. This is most pertinent to the IEEE style, where citation is of form `[\[1\]][@some]`. In this case, previous regex will see first occurrence of `]` after the number `1\`, but did not find a following `[` bracket and therefore whole link does not match.

Alternatively, I would propose to use `/\[([^]*?)\]\[([^\]]+)\]/g` for matching links. This will lazily search the first group until it finds exact `][`.

I have manually testes this regex working fine with AAA, APA, MLA, IEEE, cell, Vancouver and Nature styles.